### PR TITLE
Update LoadingSpinner.js

### DIFF
--- a/src/components/LoadingSpinner.js
+++ b/src/components/LoadingSpinner.js
@@ -14,6 +14,9 @@ export default class LoadingSpinner extends Component {
 
   render() {
     const { player } = this.props;
+    if (!player.hasStarted) {
+      return null;
+    }
     if (!player.seeking && !player.waiting) {
       return null;
     }


### PR DESCRIPTION
It should not display loading-spinner when !player.hasStarted.