### PR TITLE
Add option to always show volume control

### DIFF
--- a/src/components/control-bar/VolumeMenuButton.js
+++ b/src/components/control-bar/VolumeMenuButton.js
@@ -11,6 +11,7 @@ const propTypes = {
   actions: PropTypes.object,
   vertical: PropTypes.bool,
   className: PropTypes.string,
+  alwaysShowVolume: PropTypes.bool,
 };
 
 const defaultProps = {
@@ -76,8 +77,8 @@ class VolumeMenuButton extends Component {
           'video-react-vol-1': level === 1,
           'video-react-vol-2': level === 2,
           'video-react-vol-3': level === 3,
-          'video-react-slider-active': this.state.active,
-          'video-react-lock-showing': this.state.active,
+          'video-react-slider-active': this.props.alwaysShowVolume || this.state.active,
+          'video-react-lock-showing': this.props.alwaysShowVolume || this.state.active,
         }, 'video-react-volume-menu-button')}
         onClick={this.handleClick}
         inline={inline}


### PR DESCRIPTION
At [my job](https://esparklearning.com/), we're adding video-react to an app that's used by students in grades K-8 on iPads and Chromebooks; at the earlier ages, kids are not always familiar with various kinds of video controls or know that they can hover over the volume icon to get a slider. 

To make the interface clearer to such students, we'd like to have the volume slider always visible. To do this, this pull request adds an optional prop, `alwaysShowVolume`, to the VolumeMenuButton.

I didn't see any tests for this component, but if I missed them I'd be happy to add to them or to make any other changes you'd like.

Thanks for the great package!