### PR TITLE
Allow the hosting App to provide the store for the player to use

### DIFF
--- a/src/Manager.js
+++ b/src/Manager.js
@@ -5,8 +5,8 @@ import * as videoActions from './actions/video';
 
 
 export default class Manager {
-  constructor() {
-    this.store = createStore(reducer);
+  constructor(store) {
+    this.store = store || createStore(reducer);
 
     this.video = null;
     this.rootElement = null;

--- a/src/__tests__/reducers/player.spec.js
+++ b/src/__tests__/reducers/player.spec.js
@@ -11,11 +11,12 @@ import { FULLSCREEN_CHANGE, PLAYER_ACTIVATE, USER_ACTIVATE } from '../../actions
 describe('player', () => {
   it('should return the initail state', () => {
     const expectedInitialState = {
+      currentSrc: null,
       duration: 0,
       currentTime: 0,
       seekingTime: 0,
       buffered: null,
-      waiting: true,
+      waiting: false,
       seeking: false,
       paused: true,
       autoPaused: false,
@@ -30,8 +31,7 @@ describe('player', () => {
       hasStarted: false,
       userActivity: true,
       isActive: false,
-      isFullscreen: false,
-      currentSrc: null,
+      isFullscreen: false
     };
     expect(player(undefined, {})).toEqual(expectedInitialState);
   });

--- a/src/actions/player.js
+++ b/src/actions/player.js
@@ -1,10 +1,33 @@
 import fullscreen from '../utils/fullscreen';
+import generateActionsEnum from "../utils/generateActionEnum";
 
 export const OPERATE = 'video-react/OPERATE';
 export const FULLSCREEN_CHANGE = 'video-react/FULLSCREEN_CHANGE';
 export const PLAYER_ACTIVATE = 'video-react/PLAYER_ACTIVATE';
 export const USER_ACTIVATE = 'video-react/USER_ACTIVATE';
 
+export const Actions = generateActionsEnum([
+  OPERATE,
+  FULLSCREEN_CHANGE,
+  PLAYER_ACTIVATE,
+  USER_ACTIVATE
+]);
+
+export const ActionCreators = {
+  handleFullscreenChange,
+  activate,
+  userActivate,
+  play,
+  pause,
+  togglePlay,
+  seek,
+  forward,
+  replay,
+  changeRate,
+  changeVolume,
+  mute,
+  toggleFullscreen
+};
 
 export function handleFullscreenChange(isFullscreen) {
   return {
@@ -26,7 +49,6 @@ export function userActivate(activity) {
     activity,
   };
 }
-
 
 export function play(operation = {
   action: 'play',

--- a/src/actions/video.js
+++ b/src/actions/video.js
@@ -1,3 +1,5 @@
+import generateActionsEnum from "../utils/generateActionEnum";
+
 export const LOAD_START = 'video-react/LOAD_START';
 export const CAN_PLAY = 'video-react/CAN_PLAY';
 export const WAITING = 'video-react/WAITING';
@@ -23,6 +25,61 @@ export const LOADED_META_DATA = 'video-react/LOADED_META_DATA';
 export const LOADED_DATA = 'video-react/LOADED_DATA';
 export const RESIZE = 'video-react/RESIZE';
 export const ERROR = 'video-react/ERROR';
+
+export const Actions = generateActionsEnum([
+  LOAD_START,
+  CAN_PLAY,
+  WAITING,
+  CAN_PLAY_THROUGH,
+  PLAYING,
+  PLAY,
+  PAUSE,
+  END,
+  SEEKING,
+  SEEKED,
+  SEEKING_TIME,
+  END_SEEKING,
+  DURATION_CHANGE,
+  TIME_UPDATE,
+  VOLUME_CHANGE,
+  PROGRESS_CHANGE,
+  RATE_CHANGE,
+  SUSPEND,
+  ABORT,
+  EMPTIED,
+  STALLED,
+  LOADED_META_DATA,
+  LOADED_DATA,
+  RESIZE,
+  ERROR
+]);
+
+export const ActionCreators = {
+  handleLoadStart,
+  handleCanPlay,
+  handleWaiting,
+  handleCanPlayThrough,
+  handlePlaying,
+  handlePlay,
+  handlePause,
+  handleEnd,
+  handleSeeking,
+  handleDurationChange,
+  handleTimeUpdate,
+  handleVolumeChange,
+  handleProgressChange,
+  handleRateChange,
+  handleSuspend,
+  handleAbort,
+  handleEmptied,
+  handleStalled,
+  handleLoadedMetaData,
+  handleLoadedData,
+  handleResize,
+  handleError,
+  handleSeekingTime,
+  handleEndSeeking
+};
 
 export function handleLoadStart(videoProps) {
   return {
@@ -108,14 +165,12 @@ export function handleTimeUpdate(videoProps) {
   };
 }
 
-
 export function handleVolumeChange(videoProps) {
   return {
     type: VOLUME_CHANGE,
     videoProps
   };
 }
-
 
 export function handleProgressChange(videoProps) {
   return {
@@ -124,14 +179,12 @@ export function handleProgressChange(videoProps) {
   };
 }
 
-
 export function handleRateChange(videoProps) {
   return {
     type: RATE_CHANGE,
     videoProps,
   };
 }
-
 
 export function handleSuspend(videoProps) {
   return {

--- a/src/components/Player.js
+++ b/src/components/Player.js
@@ -56,6 +56,8 @@ const propTypes = {
   onTimeUpdate: PropTypes.func,
   onRateChange: PropTypes.func,
   onVolumeChange: PropTypes.func,
+
+  store: PropTypes.object
 };
 
 const defaultProps = {
@@ -67,13 +69,15 @@ const defaultProps = {
 
 
 export default class Player extends Component {
-  constructor(props) {
+  constructor(props, {store}) {
     super(props);
+
+    store = store || props.store;
 
     this.controlsHideTimer = null;
 
     this.video = null; // the Video component
-    this.manager = new Manager();
+    this.manager = new Manager(store);
     this.actions = this.manager.getActions();
     this.manager.subscribeToPlayerStateChange(this.handleStateChange.bind(this));
 
@@ -304,7 +308,7 @@ export default class Player extends Component {
 
   // subscribe to player state change
   subscribeToStateChange(listener) {
-    this.manager.subscribeToPlayerStateChange(listener);
+    return this.manager.subscribeToPlayerStateChange(listener);
   }
 
   // player resize
@@ -397,5 +401,6 @@ export default class Player extends Component {
   }
 }
 
+Player.contextTypes = { store: PropTypes.object };
 Player.propTypes = propTypes;
 Player.defaultProps = defaultProps;

--- a/src/index.js
+++ b/src/index.js
@@ -27,6 +27,16 @@ import RemainingTimeDisplay from './components/time-controls/RemainingTimeDispla
 import CurrentTimeDisplay from './components/time-controls/CurrentTimeDisplay';
 import DurationDisplay from './components/time-controls/DurationDisplay';
 import TimeDivider from './components/time-controls/TimeDivider';
+import { video as playerReducer } from './reducers/player';
+import { operation as operationReducer } from './reducers/operation';
+import {
+  Actions as VideoActions,
+  ActionCreators as VideoActionCreators
+} from './actions/video';
+import {
+  Actions as PlayerActions,
+  ActionCreators as PlayerActionCreators
+} from './actions/player';
 
 import '../styles/scss/video-react.scss';
 
@@ -55,5 +65,11 @@ export {
   TimeDivider,
   VolumeMenuButton,
   PlaybackRateMenuButton,
-  PlaybackRate
+  PlaybackRate,
+  playerReducer,
+  operationReducer,
+  VideoActions,
+  VideoActionCreators,
+  PlayerActions,
+  PlayerActionCreators
 };

--- a/src/reducers/operation.js
+++ b/src/reducers/operation.js
@@ -9,7 +9,7 @@ const initialState = {
 };
 
 
-export default function operation(state = initialState, action) {
+export function operation(state = initialState, action) {
   switch (action.type) {
     case OPERATE:
       return {
@@ -24,3 +24,5 @@ export default function operation(state = initialState, action) {
       return state;
   }
 }
+
+export default operation;

--- a/src/reducers/player.js
+++ b/src/reducers/player.js
@@ -34,7 +34,7 @@ const initialState = {
   isFullscreen: false,
 };
 
-export default function video(state = initialState, action) {
+export function video(state = initialState, action) {
   switch (action.type) {
     case USER_ACTIVATE:
       return {
@@ -153,3 +153,5 @@ export default function video(state = initialState, action) {
       return state;
   }
 }
+
+export default video;

--- a/src/utils/generateActionEnum.js
+++ b/src/utils/generateActionEnum.js
@@ -1,0 +1,6 @@
+export function generateActionsEnum(actionsArray) {
+  return actionsArray.reduce((actions, action) =>
+    (actions[action.replace('video-react/','')] = action) && (actions), {});
+}
+
+export default generateActionsEnum;


### PR DESCRIPTION
Addressing #80:
- Exposed reducers, actions and action creators for client app to access
- Fixed broken test
- Prepared "Player" component to receive the store either through props or context
- Now returning the unsubscribe function on Player's `subscribeToStateChange` function for consumers to kill subscription when required
- Manager uses the provided store if supplied or creates it's own if not

Hosting App now may:

1. Provide store as a prop
```js
    const store = createStore(...)
...
    render() {
      return (
        <Player poster="poster.png" store={store}>
          <source src="movie.mp4"/>

```
2. Use context to provide the store to Player
```js
import { Provider } from 'react-redux'; // e.g. using react-redux

class App extends React.Component {
  store = createStore(...)
  ...
  render() {
    return (
      <Provider store={this.store}>
          ...
      </Provider>
    );
  }
}

// Use normally. Player will read context and retrieve store
const PlayerParent = (props) => (
        <Player poster="poster.png">
          <source src="movie.mp4"/>...
```

PS. 

In regards to #80, after examining `video-react`'s design more carefully, the dataflow is not strictly what might be expected from a conventional redux app and it would require a greater effort to indeed allow the hosting app to communicate through messages (without having to pass around the manager); Regardlessly, at least this is a start to allow the hosting App to share the store that the player uses and allow developers visibility of the messages that flow through the player's store.

To clarify the dataflow point: for example, the action creator `play` is what actually triggers the play/pause to occur — and needs to be binded to the manager — instead of the play to be executed in reaction to subscribing to the store and reading `player.paused` to play or pause the video. It's like the store is always updated to reflect the state of the app but doesn't **dictate** the state of the app; at least not in all cases as far as I could see.
