### PR TITLE
Add type="button" to prevent form submit

### DIFF
--- a/src/components/control-bar/ForwardReplayControl.js
+++ b/src/components/control-bar/ForwardReplayControl.js
@@ -43,6 +43,7 @@ export default (mode) => {
             [`video-react-icon-${mode}-${seconds}`]: true,
             [`video-react-${mode}-control`]: true,
           }, 'video-react-control video-react-button video-react-icon')}
+          type="button"
           onClick={this.handleClick}
         >
           <span className="video-react-control-text">{`${mode} ${seconds} seconds`}</span>

--- a/src/components/control-bar/PlayToggle.js
+++ b/src/components/control-bar/PlayToggle.js
@@ -42,6 +42,7 @@ export default class PlayToggle extends Component {
           'video-react-paused': player.paused,
           'video-react-playing': !player.paused,
         })}
+        type="button"
         tabIndex="0"
         onClick={this.handleClick}
       >


### PR DESCRIPTION
When using the player within a `<form>`, clicking the play button causes the form to submit.
Adding `type="button"` to the button controls should prevent this behavior.