### PR TITLE
Destroy HLS source before component unmount

### DIFF
--- a/example/examples/HLSSource.js
+++ b/example/examples/HLSSource.js
@@ -29,6 +29,13 @@ export default class HLSSource extends Component {
     }
   }
 
+  componentWillUnmount() {
+    // destroy hls video source
+    if (this.hls) {
+      this.hls.destroy();
+    }
+  }
+
   render() {
     return (
       <source


### PR DESCRIPTION
After loading one or more HLS live stream sources, they keep downloading even after the player page isn't rendered.