### PR TITLE
Fix classnames overridden by props in volume bar

### DIFF
--- a/src/components/volume-control/VolumeBar.js
+++ b/src/components/volume-control/VolumeBar.js
@@ -115,8 +115,8 @@ class VolumeBar extends Component {
         onPercentageChange={this.handlePercentageChange}
         stepForward={this.stepForward}
         stepBack={this.stepBack}
-        className={classNames(className, 'video-react-volume-bar video-react-slider-bar')}
         {...this.props}
+        className={classNames(className, 'video-react-volume-bar video-react-slider-bar')}
       >
         <VolumeLevel
           {...this.props}


### PR DESCRIPTION
If `this.props.className` is set, it messes with the styling of the volume bar because `video-react-volume-bar video-react-slider-bar` does not get applied.