### PR TITLE
Allow to render tooltip with custom text

### DIFF
--- a/src/__tests__/MouseTimeDisplay.spec.js
+++ b/src/__tests__/MouseTimeDisplay.spec.js
@@ -26,4 +26,18 @@ describe('MouseTimeDisplay', () => {
       />);
     expect(wrapper.hasClass('video-react-mouse-display')).toBe(true);
   });
+
+  it('should render with custom text', () => {
+    const text = 'aloha'
+    const wrapper = shallow(
+      <MouseTimeDisplay
+        actions={{}}
+        duration={100}
+        mouseTime={{
+          time: 10,
+        }}
+        text={text}
+      />);
+    expect(wrapper.prop('data-current-time')).toEqual(text);
+  });
 });

--- a/src/components/control-bar/MouseTimeDisplay.js
+++ b/src/components/control-bar/MouseTimeDisplay.js
@@ -4,12 +4,12 @@ import classNames from 'classnames';
 
 import { formatTime } from '../../utils';
 
-function MouseTimeDisplay({ duration, mouseTime, className }) {
+function MouseTimeDisplay({ duration, mouseTime, className, text }) {
   if (!mouseTime.time) {
     return null;
   }
 
-  const time = formatTime(mouseTime.time, duration);
+  const time = text || formatTime(mouseTime.time, duration);
 
   return (
     <div


### PR DESCRIPTION
Moto: `MouseTimeDisplay` looks suitable to render custom text (show text labels instead of time for ex.).
Check tests on v0.9.4. Works like a charm.