### PR TITLE
Add "auto" support for player "width" prop

### DIFF
--- a/src/components/Player.js
+++ b/src/components/Player.js
@@ -210,7 +210,14 @@ export default class Player extends Component {
     if (fluid) {
       style.paddingTop = `${ratioMultiplier * 100}%`;
     } else {
-      style.width = `${width}px`;
+      // If Width contains "auto", set "auto" in style
+      if (width = "auto") {
+         style.width = 'auto'
+      } else {
+        // If Width contains size in pixels, set this size in style
+         style.width = `${width}px`;
+      }
+
       style.height = `${height}px`;
     }
 


### PR DESCRIPTION
"Auto" Support in props

### Example
```
            <Player fluid={false} height={520} width={"auto"}>
                <BigPlayButton position="center" />
                <source src="example.mp4" />
            </Player>
```