### PR TITLE
Fix video-react#186 className propagates to children

### DIFF
--- a/src/components/Player.js
+++ b/src/components/Player.js
@@ -114,7 +114,7 @@ export default class Player extends Component {
     }
   }
 
-  getDefaultChildren(props, fullProps) {
+  getDefaultChildren(originalChildren) {
     return [
       <Video
         ref={(c) => {
@@ -123,49 +123,45 @@ export default class Player extends Component {
         }}
         key="video"
         order={0.0}
-        {...fullProps}
-      />,
+      >
+        {originalChildren}
+      </Video>,
       <PosterImage
         key="poster-image"
         order={1.0}
-        {...props}
       />,
       <LoadingSpinner
         key="loading-spinner"
         order={2.0}
-        {...props}
       />,
       <Bezel
         key="bezel"
         order={3.0}
-        {...props}
       />,
       <BigPlayButton
         key="big-play-button"
         order={4.0}
-        {...props}
       />,
       <ControlBar
         key="control-bar"
         order={5.0}
-        {...props}
       />,
       <Shortcut
         key="shortcut"
         order={99.0}
-        {...props}
       />,
     ];
   }
 
   getChildren(props) {
-    const propsWithoutChildren = {
-      ...props,
-      children: null,
-    };
+    const {
+      className: _, // remove className
+      children: originalChildren,
+      ...propsWithoutChildren
+    } = props;
     const children = React.Children.toArray(this.props.children)
       .filter(e => (!isVideoChild(e)));
-    const defaultChildren = this.getDefaultChildren(propsWithoutChildren, props);
+    const defaultChildren = this.getDefaultChildren(originalChildren);
     return mergeAndSortChildren(defaultChildren, children, propsWithoutChildren);
   }
 

--- a/src/components/control-bar/ControlBar.js
+++ b/src/components/control-bar/ControlBar.js
@@ -41,37 +41,30 @@ export default class ControlBar extends Component {
   getDefaultChildren() {
     return [
       <PlayToggle
-        {...this.props}
         key="play-toggle"
         order={1}
       />,
       <VolumeMenuButton
-        {...this.props}
         key="volume-menu-button"
         order={4}
       />,
       <CurrentTimeDisplay
-        {...this.props}
         key="current-time-display"
         order={5.1}
       />,
       <TimeDivider
-        {...this.props}
         key="time-divider"
         order={5.2}
       />,
       <DurationDisplay
-        {...this.props}
         key="duration-display"
         order={5.3}
       />,
       <ProgressControl
-        {...this.props}
         key="progress-control"
         order={6}
       />,
       <FullscreenToggle
-        {...this.props}
         key="fullscreen-toggle"
         order={8}
       />,
@@ -81,58 +74,47 @@ export default class ControlBar extends Component {
   getFullChildren() {
     return [
       <PlayToggle
-        {...this.props}
         key="play-toggle"
         order={1}
       />,
       <ReplayControl
-        {...this.props}
         key="replay-control"
         order={2}
       />,
       <ForwardControl
-        {...this.props}
         key="forward-control"
         order={3}
       />,
       <VolumeMenuButton
-        {...this.props}
         key="volume-menu-button"
         order={4}
       />,
       <CurrentTimeDisplay
-        {...this.props}
         key="current-time-display"
         order={5}
       />,
       <TimeDivider
-        {...this.props}
         key="time-divider"
         order={6}
       />,
       <DurationDisplay
-        {...this.props}
         key="duration-display"
         order={7}
       />,
       <ProgressControl
-        {...this.props}
         key="progress-control"
         order={8}
       />,
       <RemainingTimeDisplay
-        {...this.props}
         key="remaining-time-display"
         order={9}
       />,
       <PlaybackRateMenuButton
-        {...this.props}
         rates={[1, 1.25, 1.5, 2]}
         key="playback-rate"
         order={10}
       />,
       <FullscreenToggle
-        {...this.props}
         key="fullscreen-toggle"
         order={11}
       />,
@@ -142,7 +124,8 @@ export default class ControlBar extends Component {
   getChildren() {
     const children = React.Children.toArray(this.props.children);
     const defaultChildren = this.props.disableDefaultControls ? [] : this.getDefaultChildren();
-    return mergeAndSortChildren(defaultChildren, children, this.props);
+    const { className: _, ...parentProps } = this.props; // remove className
+    return mergeAndSortChildren(defaultChildren, children, parentProps);
   }
 
   render() {

--- a/src/components/control-bar/ControlBar.js
+++ b/src/components/control-bar/ControlBar.js
@@ -124,7 +124,7 @@ export default class ControlBar extends Component {
   getChildren() {
     const children = React.Children.toArray(this.props.children);
     const defaultChildren = this.props.disableDefaultControls ? [] : this.getDefaultChildren();
-    const { className: _, ...parentProps } = this.props; // remove className
+    const { className, ...parentProps } = this.props; // remove className
     return mergeAndSortChildren(defaultChildren, children, parentProps);
   }
 

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -74,7 +74,7 @@ const isTypeEqual = (component1, component2) => {
 // filter them by `disabled` property
 export function mergeAndSortChildren(defaultChildren, _children, _parentProps, defaultOrder = 1) {
   const children = React.Children.toArray(_children);
-  const parentProps = { ..._parentProps };
+  const { order: _, ...parentProps } = _parentProps; // ignore order from parent
   return children
     .filter((e) => !e.props.disabled) // filter the disabled components
     .concat(
@@ -84,7 +84,7 @@ export function mergeAndSortChildren(defaultChildren, _children, _parentProps, d
     )
     .map((element) => {
       const defaultComponent = find(defaultChildren, (c) => isTypeEqual(c, element));
-      delete parentProps.order;
+
       const defaultProps = defaultComponent ? defaultComponent.props : {};
       const props = {
         ...parentProps, // inherit from parent component

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -67,23 +67,23 @@ const isTypeEqual = (component1, component2) => {
   }
 
   return false;
-}
+};
 
 // merge default children
 // sort them by `order` property
 // filter them by `disabled` property
 export function mergeAndSortChildren(defaultChildren, _children, _parentProps, defaultOrder = 1) {
   const children = React.Children.toArray(_children);
-  const { order: _, ...parentProps } = _parentProps; // ignore order from parent
+  const { order, ...parentProps } = _parentProps; // ignore order from parent
   return children
-    .filter((e) => !e.props.disabled) // filter the disabled components
+    .filter(e => !e.props.disabled) // filter the disabled components
     .concat(
       defaultChildren.filter(
-        (c) => !find(children, (component) => isTypeEqual(component, c))
+        c => !find(children, component => isTypeEqual(component, c))
       )
     )
     .map((element) => {
-      const defaultComponent = find(defaultChildren, (c) => isTypeEqual(c, element));
+      const defaultComponent = find(defaultChildren, c => isTypeEqual(c, element));
 
       const defaultProps = defaultComponent ? defaultComponent.props : {};
       const props = {
@@ -119,7 +119,7 @@ export function throttle(callback, limit) {
         wait = false;
       }, limit);
     }
-  }
+  };
 }
 
 export const mediaProperties = [


### PR DESCRIPTION
This MR will remove `className` from `parentProps` before calling `mergeAndSortChildren`.

Also since `mergeAndSortChildren` will merge parentProps anyways, I've removed `{...props}` `getDefaultChildren`.

TODO:
- [x] tests