### PR TITLE
New feature: Customizable delay time for auto hide of ControlBar

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -22,6 +22,7 @@
     "react/destructuring-assignment": "off",
     "react/forbid-prop-types": "off",
     "react/jsx-filename-extension": "off",
+    "react/jsx-one-expression-per-line": "literal",
     "react/no-find-dom-node": "off",
     "react/no-unused-prop-types": "off",
     "react/require-default-props": "off",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,4 @@
 {
-  "eslint.autoFixOnSave": true,
   "prettier.eslintIntegration": true,
   "javascript.validate.enable": false,
   "editor.rulers": [

--- a/docs/lib/Components/ControlBarPage.js
+++ b/docs/lib/Components/ControlBarPage.js
@@ -32,10 +32,16 @@ export default class ControlBarPage extends React.Component {
             {`ControlBar.propTypes = {
 
   // Hide the control bar automatically after the player is inactive
-  // default: 'true'
+  // default: true
   autoHide: PropTypes.bool,
+  // The waiting time for auto hide after player is inactive (in milliseconds)
+  // default: 3000
+  autoHideTime: PropType.number,
+  // Do not render default controls, only use custom ones provided as children of <ControlBar>
+  // default: false
+  disableDefaultControls: PropTypes.bool,
   // Do not render the control bar if set it to true
-  // default: 'false'
+  // default: false
   disableCompletely: PropTypes.bool,
 
 }`}

--- a/docs/lib/Components/PlayerPage.js
+++ b/docs/lib/Components/PlayerPage.js
@@ -177,17 +177,6 @@ export default function PlayerPage() {
             <td>-</td>
             <td>Seek the Video at A Specific Time On Load</td>
           </tr>
-          <tr>
-            <td>
-              <code>controlBarActiveTime</code>
-            </td>
-            <td>number</td>
-            <td>3000</td>
-            <td>
-              The time in ms that the control bar stays visible when user is no
-              longer active (no mouse moves, clicks, key presss, etc.)
-            </td>
-          </tr>
         </tbody>
       </Table>
       <h4>Properties</h4>

--- a/docs/lib/Components/PlayerPage.js
+++ b/docs/lib/Components/PlayerPage.js
@@ -177,6 +177,17 @@ export default function PlayerPage() {
             <td>-</td>
             <td>Seek the Video at A Specific Time On Load</td>
           </tr>
+          <tr>
+            <td>
+              <code>controlBarActiveTime</code>
+            </td>
+            <td>number</td>
+            <td>3000</td>
+            <td>
+              The time in ms that the control bar stays visible when user is no
+              longer active (no mouse moves, clicks, key presss, etc.)
+            </td>
+          </tr>
         </tbody>
       </Table>
       <h4>Properties</h4>

--- a/src/components/Player.js
+++ b/src/components/Player.js
@@ -34,7 +34,6 @@ const propTypes = {
   src: PropTypes.string,
   poster: PropTypes.string,
   preload: PropTypes.oneOf(['auto', 'metadata', 'none']),
-  controlBarActiveTime: PropTypes.number,
 
   onLoadStart: PropTypes.func,
   onWaiting: PropTypes.func,
@@ -66,8 +65,7 @@ const defaultProps = {
   fluid: true,
   muted: false,
   playsInline: false,
-  aspectRatio: 'auto',
-  controlBarActiveTime: 3000
+  aspectRatio: 'auto'
 };
 
 export default class Player extends Component {
@@ -337,7 +335,18 @@ export default class Player extends Component {
   }
 
   startControlsTimer() {
-    const { controlBarActiveTime } = this.props;
+    let controlBarActiveTime = 3000;
+    React.Children.forEach(this.props.children, element => {
+      if (!React.isValidElement(element) || element.type !== ControlBar) {
+        return;
+      }
+
+      const { autoHideTime } = element.props;
+      if (typeof autoHideTime === 'number') {
+        controlBarActiveTime = autoHideTime;
+      }
+    });
+
     this.actions.userActivate(true);
     clearTimeout(this.controlsHideTimer);
     this.controlsHideTimer = setTimeout(() => {

--- a/src/components/Player.js
+++ b/src/components/Player.js
@@ -34,6 +34,7 @@ const propTypes = {
   src: PropTypes.string,
   poster: PropTypes.string,
   preload: PropTypes.oneOf(['auto', 'metadata', 'none']),
+  controlBarActiveTime: PropTypes.number,
 
   onLoadStart: PropTypes.func,
   onWaiting: PropTypes.func,
@@ -65,7 +66,8 @@ const defaultProps = {
   fluid: true,
   muted: false,
   playsInline: false,
-  aspectRatio: 'auto'
+  aspectRatio: 'auto',
+  controlBarActiveTime: 3000
 };
 
 export default class Player extends Component {
@@ -335,11 +337,12 @@ export default class Player extends Component {
   }
 
   startControlsTimer() {
+    const { controlBarActiveTime } = this.props;
     this.actions.userActivate(true);
     clearTimeout(this.controlsHideTimer);
     this.controlsHideTimer = setTimeout(() => {
       this.actions.userActivate(false);
-    }, 3000);
+    }, controlBarActiveTime);
   }
 
   handleStateChange(state, prevState) {

--- a/src/components/control-bar/ControlBar.js
+++ b/src/components/control-bar/ControlBar.js
@@ -18,6 +18,7 @@ import { mergeAndSortChildren } from '../../utils';
 const propTypes = {
   children: PropTypes.any,
   autoHide: PropTypes.bool,
+  autoHideTime: PropTypes.number, // used in Player
   disableDefaultControls: PropTypes.bool,
   disableCompletely: PropTypes.bool,
   className: PropTypes.string


### PR DESCRIPTION
Implements #146

Initially I added `controlBarActiveTime` on `Player` level. However, I think it's much more intuitive to move this prop to `ControlBar` level. I used a trick to read it from children in `Player` so it can be a prop of `ControlBar`.

Let me know if you have any concerns.