### PR TITLE
[video-react/video-react#237] Support non-Rollup/ES6-based toolchains

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "video-react",
   "version": "0.13.4",
   "description": "Video-React is a web video player built from the ground up for an HTML5 world using React library.",
-  "main": "lib/index.js",
+  "module": "dist/video-react.es.js",
+  "main": "dist/video-react.full.js",
   "style": "dist/video-react.css",
   "scripts": {
     "test": "BABEL_ENV=test jest",


### PR DESCRIPTION
This fixes the issues I've been having (please see video-react/video-react#237) and I hope that it fixes import problems for others. This seems to be the preferred way to publish modules [per Rollup's documentation](https://github.com/rollup/rollup/wiki/pkg.module).

I may have something wrong here in terms of supporting non-Webpack environments like Rollup, as I am not really familiar with that tool!