### PR TITLE
fix: add tabindex to video tag to make it focusable (#262)

### DIFF
--- a/src/components/Video.js
+++ b/src/components/Video.js
@@ -551,6 +551,7 @@ export default class Video extends Component {
         onTimeUpdate={this.handleTimeUpdate}
         onRateChange={this.handleRateChange}
         onVolumeChange={this.handleVolumeChange}
+        tabIndex="-1"
       >
         {this.renderChildren()}
       </video>


### PR DESCRIPTION
closes #262

Latest Chrome no longer consider video as a focusable element by default