### PR TITLE
fix: re-focus to root element when switching fullscreen (#276)

### DIFF
--- a/src/components/Player.js
+++ b/src/components/Player.js
@@ -13,6 +13,7 @@ import Shortcut from './Shortcut';
 import ControlBar from './control-bar/ControlBar';
 
 import * as browser from '../utils/browser';
+import { focusNode } from '../utils/dom';
 import { mergeAndSortChildren, isVideoChild, throttle } from '../utils';
 import fullscreen from '../utils/fullscreen';
 
@@ -358,6 +359,8 @@ export default class Player extends Component {
   handleStateChange(state, prevState) {
     if (state.isFullscreen !== prevState.isFullscreen) {
       this.handleResize();
+      // focus root when switching fullscreen mode to avoid confusion #276
+      focusNode(this.manager.rootElement);
     }
     this.forceUpdate(); // re-render
   }

--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -80,6 +80,14 @@ export function blurNode(reactNode) {
   }
 }
 
+// focus an element
+export function focusNode(reactNode) {
+  const domNode = findDOMNode(reactNode);
+  if (domNode && domNode.focus) {
+    domNode.focus();
+  }
+}
+
 // check if an element has a class name
 export function hasClass(elm, cls) {
   const classes = elm.className.split(' ');


### PR DESCRIPTION
closes #276