### PR TITLE
Google cast support with docs

### DIFF
--- a/docs/lib/Customize/GoogleCastPage.js
+++ b/docs/lib/Customize/GoogleCastPage.js
@@ -1,0 +1,49 @@
+/* eslint react/no-multi-comp: 0, react/prop-types: 0 */
+import React from 'react';
+import { PrismCode } from 'react-prism';
+import { Button } from 'reactstrap';
+import Helmet from 'react-helmet';
+import GoogleCastExample from '../examples/GoogleCast';
+
+const GoogleCastExampleSource = require('!!raw-loader!../examples/GoogleCast');
+const CastPlayToggleSource = require('!!raw-loader!../../../src/components/control-bar/CastPlayToggle');
+
+export default class GoogleCastPage extends React.Component {
+  render() {
+    return (
+      <div>
+        <Helmet title="Google cast support" />
+        <h3>Google Cast Support</h3>
+        Cast support can be implemented in three steps.
+        <ol>
+          <li>Import the google part of the code with a script tag.</li>
+          <li>
+            Handle the basic framework functionality in a component wrapping
+            your player.
+          </li>
+          <li>
+            Create control bar components that are aware of whether they control
+            the local or remote player. See the modified PlayToggle,
+            CastPlayToggle, below.
+          </li>
+        </ol>
+        <div className="docs-example">
+          <GoogleCastExample />
+        </div>
+        <pre>
+          <PrismCode className="language-jsx">
+            {GoogleCastExampleSource}
+          </PrismCode>
+        </pre>
+        <h4>CastPlayToggle</h4>
+        <pre>
+          <PrismCode className="language-jsx">{CastPlayToggleSource}</PrismCode>
+        </pre>
+        <script
+          type="text/javascript"
+          src="https://www.gstatic.com/cv/js/sender/v1/cast_sender.js?loadCastFramework=1"
+        />
+      </div>
+    );
+  }
+}

--- a/docs/lib/Customize/index.js
+++ b/docs/lib/Customize/index.js
@@ -27,6 +27,10 @@ class Customize extends React.Component {
         {
           name: 'Customize Video Source',
           to: '/customize/customize-source/'
+        },
+        {
+          name: 'Google Cast Support',
+          to: '/customize/google-cast/'
         }
       ]
     };

--- a/docs/lib/examples/GoogleCast.js
+++ b/docs/lib/examples/GoogleCast.js
@@ -1,0 +1,128 @@
+import React from 'react';
+import {
+  Player,
+  ControlBar,
+  PlayToggle,
+  ReplayControl,
+  ForwardControl,
+  CurrentTimeDisplay,
+  TimeDivider,
+  PlaybackRateMenuButton,
+  VolumeMenuButton
+} from 'video-react';
+import CastPlayToggle from '../../../src/components/control-bar/CastPlayToggle';
+
+export default class GoogleCastComponent extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      isCasting: false,
+      castError: null
+    };
+  }
+
+  componentDidMount() {
+    // eslint-disable-next-line no-underscore-dangle
+    window.__onGCastApiAvailable = isAvailable => {
+      if (isAvailable) {
+        this.initializeCastPlayer();
+      }
+    };
+  }
+
+  // Cast functions
+  setupRemotePlayer() {
+    const mediaInfo = new chrome.cast.media.MediaInfo(
+      this.refs.player.getState().player.currentSrc,
+      'video/mp4'
+    );
+    mediaInfo.streamType = chrome.cast.media.StreamType.BUFFERED;
+
+    const request = new chrome.cast.media.LoadRequest(mediaInfo);
+
+    cast.framework.CastContext.getInstance()
+      .getCurrentSession()
+      .loadMedia(request)
+      .then(
+        () => {
+          this.setState({
+            isCasting: true,
+            castError: null
+          });
+
+          this.remotePlayer.currentTime = this.refs.player.getState().player.currentTime;
+          this.remotePlayerController.seek();
+        },
+        errorCode => {
+          this.setState({
+            castError: errorCode
+          });
+        }
+      );
+
+    // this.setState({
+    //   isCasting: true
+    // });
+  }
+
+  toggleCastState() {
+    if (cast && cast.framework && this.remotePlayer.isConnected) {
+      // Pause local playback
+      this.refs.player.pause();
+      this.setupRemotePlayer();
+    } else {
+      this.setState({
+        isCasting: false
+      });
+    }
+  }
+
+  initializeCastPlayer() {
+    cast.framework.CastContext.getInstance().setOptions({
+      receiverApplicationId: chrome.cast.media.DEFAULT_MEDIA_RECEIVER_APP_ID
+    });
+
+    this.remotePlayer = new cast.framework.RemotePlayer();
+    this.remotePlayerController = new cast.framework.RemotePlayerController(
+      this.remotePlayer
+    );
+    this.remotePlayerController.addEventListener(
+      cast.framework.RemotePlayerEventType.IS_CONNECTED_CHANGED,
+      this.toggleCastState.bind(this)
+    );
+  }
+  // End Cast functions
+
+  render() {
+    return (
+      <>
+        <Player ref="player" poster="/assets/poster.png">
+          <source src="https://media.w3.org/2010/05/sintel/trailer_hd.mp4" />
+
+          <ControlBar>
+            <PlayToggle disabled />
+            <CastPlayToggle
+              order={1}
+              isCasting={this.state.isCasting}
+              remotePlayer={this.remotePlayer}
+              remotePlayerController={this.remotePlayerController}
+            />
+            <ReplayControl seconds={10} order={1.1} />
+            <ForwardControl seconds={30} order={1.2} />
+            <CurrentTimeDisplay order={4.1} />
+            <TimeDivider order={4.2} />
+            <PlaybackRateMenuButton rates={[5, 2, 1, 0.5, 0.1]} order={7.1} />
+            <VolumeMenuButton disabled />
+            <google-cast-launcher
+              is="google-cast-button"
+              id="castbutton"
+              order={9}
+              style={{ width: '40px', height: '30px', padding: '4px' }}
+            />
+          </ControlBar>
+        </Player>
+        {this.state.castError && <p>{this.state.castError}</p>}
+      </>
+    );
+  }
+}

--- a/docs/lib/examples/GoogleCast.js
+++ b/docs/lib/examples/GoogleCast.js
@@ -2,12 +2,10 @@ import React from 'react';
 import {
   Player,
   ControlBar,
-  PlayToggle,
-  ReplayControl,
-  ForwardControl,
   CurrentTimeDisplay,
   TimeDivider,
-  PlaybackRateMenuButton,
+  DurationDisplay,
+  ProgressControl,
   VolumeMenuButton
 } from 'video-react';
 import CastPlayToggle from '../../../src/components/control-bar/CastPlayToggle';
@@ -99,20 +97,17 @@ export default class GoogleCastComponent extends React.Component {
         <Player ref="player" poster="/assets/poster.png">
           <source src="https://media.w3.org/2010/05/sintel/trailer_hd.mp4" />
 
-          <ControlBar>
-            <PlayToggle disabled />
+          <ControlBar disableDefaultControls>
             <CastPlayToggle
               order={1}
               isCasting={this.state.isCasting}
               remotePlayer={this.remotePlayer}
               remotePlayerController={this.remotePlayerController}
             />
-            <ReplayControl seconds={10} order={1.1} />
-            <ForwardControl seconds={30} order={1.2} />
-            <CurrentTimeDisplay order={4.1} />
-            <TimeDivider order={4.2} />
-            <PlaybackRateMenuButton rates={[5, 2, 1, 0.5, 0.1]} order={7.1} />
-            <VolumeMenuButton disabled />
+            <CurrentTimeDisplay disabled={this.state.isCasting} order={4.1} />
+            <TimeDivider disabled={this.state.isCasting} order={4.2} />
+            <DurationDisplay disabled={this.state.isCasting} order={4.3} />
+            <ProgressControl disabled={this.state.isCasting} order={6} />
             <google-cast-launcher
               is="google-cast-button"
               id="castbutton"

--- a/docs/lib/routes.js
+++ b/docs/lib/routes.js
@@ -21,6 +21,7 @@ import Customize from './Customize';
 import EnableDisableComponentPage from './Customize/EnableDisableComponentPage';
 import CustomizeComponentPage from './Customize/CustomizeComponentPage';
 import CustomizeSourcePage from './Customize/CustomizeSourcePage';
+import GoogleCastPage from './Customize/GoogleCastPage';
 
 const routes = (
   <Route path="/" component={UI.Layout}>
@@ -52,6 +53,7 @@ const routes = (
       />
       <Route path="customize-component/" component={CustomizeComponentPage} />
       <Route path="customize-source/" component={CustomizeSourcePage} />
+      <Route path="google-cast/" component={GoogleCastPage} />
     </Route>
     <Route path="*" component={NotFound} />
   </Route>

--- a/src/__tests__/CastPlayToggle.spec.js
+++ b/src/__tests__/CastPlayToggle.spec.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import sinon from 'sinon';
 import PlayToggle from '../components/control-bar/PlayToggle';
 import CastPlayToggle from '../components/control-bar/CastPlayToggle';
 

--- a/src/__tests__/CastPlayToggle.spec.js
+++ b/src/__tests__/CastPlayToggle.spec.js
@@ -1,0 +1,79 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import sinon from 'sinon';
+import PlayToggle from '../components/control-bar/PlayToggle';
+import CastPlayToggle from '../components/control-bar/CastPlayToggle';
+
+describe('CastPlayToggle', () => {
+  it('should render with "button" tag when casting', () => {
+    const wrapper = shallow(
+      <CastPlayToggle
+        remotePlayer={{
+          isPaused: true
+        }}
+        isCasting
+      />
+    );
+
+    expect(wrapper.type()).toBe('button');
+  });
+
+  it('should render with "PlayToggle" component when not casting', () => {
+    const wrapper = shallow(<CastPlayToggle />);
+
+    expect(wrapper.type()).toBe(PlayToggle);
+  });
+
+  it('should render with "video-react-button" class', () => {
+    const wrapper = shallow(
+      <CastPlayToggle
+        isCasting
+        remotePlayer={{
+          isPaused: false
+        }}
+      />
+    );
+    expect(wrapper.hasClass('video-react-button')).toBe(true);
+  });
+
+  it('should render with "video-react-paused" class when video has been paused', () => {
+    const wrapper = shallow(
+      <CastPlayToggle
+        isCasting
+        remotePlayer={{
+          isPaused: true
+        }}
+      />
+    );
+    expect(wrapper.hasClass('video-react-paused')).toBe(true);
+  });
+
+  it('should render with "video-react-playing" class when video is playing', () => {
+    const wrapper = shallow(
+      <CastPlayToggle
+        isCasting
+        remotePlayer={{
+          isPaused: false
+        }}
+      />
+    );
+    expect(wrapper.hasClass('video-react-playing')).toBe(true);
+  });
+
+  it('should render with "video-react-playing" class when video is playing', () => {
+    const playOrPauseFunc = jest.fn();
+    const wrapper = shallow(
+      <CastPlayToggle
+        isCasting
+        remotePlayer={{
+          isPaused: false
+        }}
+        remotePlayerController={{
+          playOrPause: playOrPauseFunc
+        }}
+      />
+    );
+    wrapper.find('button').simulate('click');
+    expect(playOrPauseFunc).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/control-bar/CastPlayToggle.js
+++ b/src/components/control-bar/CastPlayToggle.js
@@ -1,0 +1,57 @@
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import classNames from 'classnames';
+import PlayToggle from './PlayToggle';
+
+const propTypes = {
+  actions: PropTypes.object,
+  player: PropTypes.object,
+  className: PropTypes.string
+};
+
+export default class CastPlayToggle extends Component {
+  constructor(props, context) {
+    super(props, context);
+    this.handleClick = this.handleClick.bind(this);
+  }
+
+  handleClick() {
+    const { remotePlayerController } = this.props;
+    remotePlayerController.playOrPause();
+  }
+
+  render() {
+    const { remotePlayer, className } = this.props;
+
+    // Controls remote player
+    if (this.props.isCasting) {
+      const controlText = remotePlayer.isPaused ? 'Play' : 'Pause';
+
+      return (
+        <button
+          ref={c => {
+            this.button = c;
+          }}
+          className={classNames(className, {
+            'video-react-play-control': true,
+            'video-react-control': true,
+            'video-react-button': true,
+            'video-react-paused': remotePlayer.isPaused,
+            'video-react-playing': !remotePlayer.isPaused
+          })}
+          type="button"
+          tabIndex="0"
+          onClick={this.handleClick}
+        >
+          <span className="video-react-control-text">{controlText}</span>
+        </button>
+      );
+    }
+
+    // Controls local player
+    return <PlayToggle {...this.props} />;
+  }
+}
+
+CastPlayToggle.propTypes = propTypes;
+CastPlayToggle.displayName = 'CastPlayToggle';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,9 +11,10 @@ const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
 
 const outputFilename = 'video-react';
 const minimizer = env === 'production' ? [new UglifyJsPlugin()] : [];
-const outputFile = env === 'production'
-  ? `${outputFilename.toLowerCase()}.min.js`
-  : `${outputFilename.toLowerCase()}.js`;
+const outputFile =
+  env === 'production'
+    ? `${outputFilename.toLowerCase()}.min.js`
+    : `${outputFilename.toLowerCase()}.js`;
 
 const paths = [
   '/',
@@ -34,6 +35,7 @@ const paths = [
   '/customize/enable-disable-components/',
   '/customize/customize-source/',
   '/customize/customize-component/',
+  '/customize/google-cast/',
   '/404.html'
 ];
 


### PR DESCRIPTION
A very simple implementation of a cast sender application, for Chromecast and other receivers. The only working button in the control bar is the `PlayToggle`. This can serve as a base for further implementation of the components required by projects.

I made a `CastPlayToggle` component that wraps the regular `PlayToggle` so the easiest implementation is to disable the default controls and use this one instead. Another way is to let the `CastPlayToggle` handle only the "remote player" and switching between controls in the `ControlBar` component instead, i.e.
```
<PlayToggle disabled={this.state.isCasting} />
<CastPlayToggle disabled={!this.state.isCasting} />
```
 Let me know if anyone has thoughts about other approaches to the local/remote player controls and state display.