### PR TITLE
avoid css conflict by stalying class instead of button elemnt

### DIFF
--- a/src/components/BigPlayButton.js
+++ b/src/components/BigPlayButton.js
@@ -32,6 +32,7 @@ export default class BigPlayButton extends Component {
     return (
       <button
         className={classNames(
+          'video-react-button',
           'video-react-big-play-button',
           `video-react-big-play-button-${position}`,
           this.props.className,

--- a/styles/scss/components/button.scss
+++ b/styles/scss/components/button.scss
@@ -1,4 +1,4 @@
-.video-react button {
+.video-react .video-react-button {
   background: none;
   border: none;
   color: inherit;


### PR DESCRIPTION
The `.video-react button` style is creating CSS conflict when I try to create custom controls with my own UI library.
Instead of styling the `<button>` element I styled the `video-react button` class (which was already used in other places).

Edit: just applied the same fix for `<ul>` elements