### PR TITLE
adding in position absolute for full screen

### DIFF
--- a/src/components/Player.js
+++ b/src/components/Player.js
@@ -167,7 +167,9 @@ export default class Player extends Component {
   }
 
   setPosition(style, name, value) {
-    Object.assign(style, (0, _defineProperty2["default"])({}, name, value));
+    Object.assign(style, {
+      [name]: value
+    });
   }
 
   getStyle() {
@@ -326,7 +328,7 @@ export default class Player extends Component {
   }
 
   // player resize
-  handleResize() {}
+  handleResize() { }
 
   handleFullScreenChange(event) {
     if (event.target === this.manager.rootElement) {

--- a/src/components/Player.js
+++ b/src/components/Player.js
@@ -22,6 +22,7 @@ const propTypes = {
 
   width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   height: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  position: PropTypes.string,
   fluid: PropTypes.bool,
   muted: PropTypes.bool,
   playsInline: PropTypes.bool,
@@ -165,6 +166,10 @@ export default class Player extends Component {
     });
   }
 
+  setPosition(style, name, value) {
+    Object.assign(style, (0, _defineProperty2["default"])({}, name, value));
+  }
+
   getStyle() {
     const {
       fluid,
@@ -219,6 +224,9 @@ export default class Player extends Component {
       // If Width contains "auto", set "auto" in style
       this.setWidthOrHeight(style, 'width', width);
       this.setWidthOrHeight(style, 'height', height);
+      if (height === "100%" && width === "100%") {
+        this.setPosition(style, 'position', "absolute")
+      }
     }
 
     return style;


### PR DESCRIPTION
PR tying to github issue:

https://github.com/video-react/video-react/issues/260

If you use height and width of 100% as props the video doesn't show up on the screen.  Need to set position to absolute if height and width are 100% in order to show the video.  Adding in checks to see if 100% is passed in for both of these and if so then setting the style position to absolute.

